### PR TITLE
Allow greater control for xml output and fix bugs with display output

### DIFF
--- a/Extensions/StringExtensions.cs
+++ b/Extensions/StringExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 
 namespace WebAdvanced.Sitemap.Extensions {
@@ -9,6 +9,10 @@ namespace WebAdvanced.Sitemap.Extensions {
         }
 
         public static string SlugToTitle(this string slug) {
+            if (string.IsNullOrWhiteSpace(slug))
+            {
+                return string.Empty;
+            }
             var parts = slug.Split('-');
             return String.Join(" ", parts.Select(p => {
                 char[] a = p.ToCharArray();

--- a/Providers/ISitemapRouteProvider.cs
+++ b/Providers/ISitemapRouteProvider.cs
@@ -9,5 +9,6 @@ namespace WebAdvanced.Sitemap.Providers {
     public interface ISitemapRouteProvider : IDependency {
         IEnumerable<SitemapRoute> GetDisplayRoutes();
         IEnumerable<SitemapRoute> GetXmlRoutes();
+        int SequenceNumber { get; }
     }
 }

--- a/Providers/Impl/ContentRouteProvider.cs
+++ b/Providers/Impl/ContentRouteProvider.cs
@@ -65,5 +65,8 @@ namespace WebAdvanced.Sitemap.Providers.Impl {
 
             return new List<SitemapRoute>();
         }
+        
+        public int SequenceNumber { get { return 20; } }
+        
     }
 }

--- a/Providers/Impl/CustomRouteProvider.cs
+++ b/Providers/Impl/CustomRouteProvider.cs
@@ -29,5 +29,8 @@ namespace WebAdvanced.Sitemap.Providers.Impl {
                     UpdateFrequency = r.UpdateFrequency})
                 .AsEnumerable();
         }
+        
+        public int SequenceNumber { get { return 10; } }
+        
     }
 }

--- a/Services/AdvancedSitemapService.cs
+++ b/Services/AdvancedSitemapService.cs
@@ -144,11 +144,11 @@ namespace WebAdvanced.Sitemap.Services {
             var existingRouteIds = new List<int>();
 
             foreach (var model in routes) {
-                // Throw out empty urls
-                if (String.IsNullOrEmpty(model.Url))
-                    continue;
-                if (model.Url.Trim() == String.Empty)
-                    continue;
+                // Treat empty url as over-ride for root path
+                if (string.IsNullOrWhiteSpace(model.Url))
+                {
+                    model.Url = string.Empty;
+                }
 
                 var customRouteModel = model;
                 var record = _customRouteRepository.Fetch(q => q.Url == customRouteModel.Url).FirstOrDefault();

--- a/Services/AdvancedSitemapService.cs
+++ b/Services/AdvancedSitemapService.cs
@@ -209,7 +209,7 @@ namespace WebAdvanced.Sitemap.Services {
                         // Get all base paths
                         foreach (var route in routes) {
                             var slugParts = route.Url.Trim('/').Split('/');
-                            if (slugParts.Count() == 1) {
+                            if (slugParts.Count() == 1 && !string.IsNullOrWhiteSpace(route.Title)) {
                                 slugs[slugParts[0]] = route.Title;
                             }
                             else {
@@ -298,16 +298,20 @@ namespace WebAdvanced.Sitemap.Services {
                         SitemapNode currentNode = sitemap;
                         while (i < slugs.Length) {
                             var isLeaf = i == slugs.Length - 1;
-                            string name = isLeaf ? item.Title : slugs[i].SlugToTitle();
-                            string url = isLeaf ? item.Url : null;
-                            if (!currentNode.Children.ContainsKey(slugs[i])) {
+                            if (!currentNode.Children.ContainsKey(slugs[i]))
+                            {
+                                string name = isLeaf ? item.Title : slugs[i].SlugToTitle();
+                                string url = isLeaf ? item.Url : null;
                                 currentNode.Children.Add(slugs[i], new SitemapNode(name, url));
                             }
-                            else if (!string.IsNullOrEmpty(currentNode.Children[slugs[i]].Url))
+                            else if (isLeaf) // Only replace existing items if the current is a leaf
                             {
-                                // TODO: A better way to tell whether to overwrite a previous node?
-                                currentNode.Children[slugs[i]].Url = url;
-                                currentNode.Children[slugs[i]].Title = name;
+                                currentNode.Children[slugs[i]].Url = item.Url;
+                                // Keep current title if the over-riding one is empty  when a custom route is over-riding a content route
+                                if (!string.IsNullOrWhiteSpace(item.Title)) 
+                                {
+                                    currentNode.Children[slugs[i]].Title = item.Title; 
+                                }
                             }
                             currentNode = currentNode.Children[slugs[i]];
                             i++;

--- a/Views/Admin/Cache.cshtml
+++ b/Views/Admin/Cache.cshtml
@@ -1,7 +1,7 @@
-﻿@{
+@{
     Layout.Title = T("Sitemap Cache").ToString();
 }
-@using(Html.BeginFormAntiForgeryPost("RefreshXmlCache", FormMethod.Get)) {
+@using(Html.BeginFormAntiForgeryPost("RefreshCache", FormMethod.Get)) {
     <legend>Reset Cache</legend>
     <p>The XML sitemap is normally cached on an hourly basis. The sitemap display and settings are cached until content updates. Click the button below to force a cache reset.</p>
     <fieldset>

--- a/Views/Sitemap.Group.cshtml
+++ b/Views/Sitemap.Group.cshtml
@@ -1,5 +1,5 @@
 ﻿<div class="item-group">
-    @if (String.IsNullOrEmpty((string)Model.Url)) {
+    @if (Model.Url == null) {
         <h2>@Model.Title</h2>
     }
     else {


### PR DESCRIPTION
Please consider pulling in the changes in this request. 
1. Home page (root page) now has link generated in sitemap display output
2. Links and Titles correctly generated when nested pages and custom routes are combined.
3. Ability to over-ride content routes with custom routes to set different priority/frequency for output to sitemap.xml.
4. Improved ordering of items output to sitemap.xml (highest priority first).
